### PR TITLE
Adding checks to base64 to prevent common false positives.

### DIFF
--- a/multidecoder/base64.py
+++ b/multidecoder/base64.py
@@ -11,6 +11,9 @@ HTML_ESCAPE_RE = rb'&#(?:x[a-fA-F0-9]{1,4}|\d{1,4});'
 BASE64_RE = rb'(?:[A-Za-z0-9+/]{4,}(?:<\x00  \x00)?(?:&#13;|&#xD;)?(?:&#10;|&#xA)?\r?\n?){3,}' \
             rb'[A-Za-z0-9+/]{2,}={0,2}'
 
+CAMEL_RE = rb'(?:[A-Z][a-z]{3,})+'
+HEX_RE = rb'[a-z0-9]+'
+
 MIN_B64_CHARS = 6
 
 def base64_search(text: bytes) -> Dict[bytes, bytes]:
@@ -29,6 +32,14 @@ def base64_search(text: bytes) -> Dict[bytes, bytes]:
             continue
         b64_string = re.sub(HTML_ESCAPE_RE, b'', b64_match).replace(b'\n', b'').replace(b'\r', b'') \
                 .replace(b'<\x00  \x00', b'')
+        if re.fullmatch(HEX_RE, b64_string):
+            # Hexadecimal characters are a subset of base64
+            # Hashes commonly are hex and have multiple of 4 lengths
+            continue
+        if re.fullmatch(CAMEL_RE, b64_string):
+            # Camel case text can be confused for base64
+            # It is common in scripts as names
+            continue
         uniq_char = set(b64_string)
         if len(uniq_char) > MIN_B64_CHARS and len(b64_string) % 4 == 0:
             try:

--- a/test/test_b64.py
+++ b/test/test_b64.py
@@ -5,6 +5,13 @@ from multidecoder.base64 import base64_search
 def test_base64_search_empty():
     assert base64_search(b'') == {}
 
+def test_base64_search_hex():
+    assert base64_search(b'0123456789abcdef') == {}
+    assert base64_search(b'2fd4e1c67a2d28fced849ee1bb76e7391b93eb12') == {}
+
+def test_base64_search_camel():
+    assert base64_search(b'CamelCaseTesting') == {}
+
 ENCODED = binascii.b2a_base64(b'Some base64 encoded text')
 TEST_STRINGS = {
     ENCODED: {ENCODED.strip(): b'Some base64 encoded text'},


### PR DESCRIPTION
Added a check for CamelCase strings to prevent variable names in
scripts from being mistaken for base64.
Added a check for hexadecimal strings to prevent hashes
and other hex encodings from being mistaken for base64