### PR TITLE
Adding helper to invert tree to query.py

### DIFF
--- a/multidecoder/__main__.py
+++ b/multidecoder/__main__.py
@@ -39,7 +39,8 @@ def main():
     if args.json:
         print(tree_to_json(tree))
         return
-    string_summary(tree)
+    for string in string_summary(tree):
+        print(string)
 
 
 if __name__ == '__main__':

--- a/multidecoder/query.py
+++ b/multidecoder/query.py
@@ -1,24 +1,48 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Optional
 
 
-def make_label(stack, value) -> str:
+class Node():
+    def __init__(self,
+                 type: str,
+                 value: bytes,
+                 obfuscation: str,
+                 parent: Optional[Node],
+                 start: int = 0,
+                 end: int = 0):
+        self.type = type
+        self.value = value
+        self.obfuscation = obfuscation
+        self.start = start
+        self.end = end
+        self.parent = parent
+
+
+def invert_tree(tree: list[dict[str, Any]]):
+    def invert_helper(tree: list[dict[str, Any]], parent: Optional[Node]):
+        nodes = []
+        for d in tree:
+            node = Node(d['type'], d['value'], d['obfuscation'], parent, d['start'], d['end'])
+            nodes.append(node)
+            nodes.extend(invert_helper(d['children'], node))
+        return nodes
+    return invert_helper(tree, None)
+
+
+def make_label(node: Optional[Node]) -> str:
     label_list = []
-    for node in stack:
-        if node['obfuscation']:
-            label_list.append('>'+node['obfuscation'])
-        if node['type']:
-            label_list.append(node['type'])
-    return '/'.join(label_list)
+    value = node.value if node else b''
+    while node:
+        if node.obfuscation:
+            label_list.append('>'+node.obfuscation)
+        if node.type:
+            label_list.append(node.type)
+        node = node.parent
+    return '/'.join(label_list) + ' ' + repr(value)[2:-1]
 
 
-def string_summary(tree: list[dict[str, Any]], stack=None) -> None:
-    if stack is None:
-        stack = []
-    for node in tree:
-        stack.append(node)
-        print(make_label(stack, node['value']), node['value'])
-        if 'children' in node and node['children']:
-            string_summary(node['children'], stack)
-        stack.pop()
+def string_summary(tree: list[dict[str, Any]]) -> list[str]:
+    return [
+        make_label(node) for node in invert_tree(tree)
+    ]


### PR DESCRIPTION
- new class Node for inverted tree that stores the parent instead of
  the children
- new function invert_tree that returns a list of all the dictionaries
  of the context tree converted to Nodes
- make_label and string_summary changed to use invert_tree and Node
- make_label now returns the combined label value pair
- string_summary now returns a list of strings instead of printing them