### PR TITLE
Add version fallback for git archive installs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,3 +9,4 @@ build-backend = "setuptools.build_meta"
 # setuptools_scm
 [tool.setuptools_scm]
 write_to = "multidecoder/_version.py"
+fallback_version = "0.0.0"


### PR DESCRIPTION
Without the fallback setuptools_scm errors when installing from a git archive as there is no version information