### PR TITLE
Depricate query (#59)

### DIFF
--- a/src/multidecoder/node.py
+++ b/src/multidecoder/node.py
@@ -36,17 +36,33 @@ class Node:
             return self.parent.value[self.start : self.end]
         return self.value
 
+    def flatten(self) -> bytes:
+        """Flatten the node's sub-tree into a single deobfuscated value.
+
+        Returns the node's value with each child node's original data
+        replaced by it's decoded value.
+        This is done recursively, with each child node flattened to include
+        all of it's children's deobfuscations before replacement.
+        """
+        offset = 0
+        output = []
+        for node in self.children:
+            if node.start < offset:
+                continue  # Only take the first of overlapping values
+            node_data = node.flatten()
+            if node_data != self.value[node.start : node.end]:
+                output.append(self.value[offset : node.start])
+                if node.type.endswith("string"):
+                    node_data = b'"' + node_data + b'"'
+                output.append(node_data)
+                offset = node.end
+        output.append(self.value[offset:])
+        return b"".join(output)
+
     def shift(self: Node, offset: int) -> Node:
-        """Shift the start and end value of a node by and offset
+        """Shift the node's start and end value by an offset.
 
         The node is modified in place.
-
-        Args:
-            node: The node to be shifted.
-            offset: The ammount to shift.
-
-        Returns:
-            The modified node.
         """
         self.start += offset
         self.end += offset

--- a/src/multidecoder/query.py
+++ b/src/multidecoder/query.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from collections import Counter
 from typing import TYPE_CHECKING
 
@@ -8,6 +9,11 @@ if TYPE_CHECKING:
 
 
 def invert_tree(tree: list[Node]) -> list[Node]:
+    warnings.warn(
+        "invert_tree is obsolete. Use list(root_node) instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     nodes: list[Node] = []
     for node in tree:
         nodes.extend(node)
@@ -30,6 +36,7 @@ def string_summary(tree: Node) -> list[str]:
 
 
 def squash_replace(data: bytes, tree: list[Node]) -> bytes:
+    warnings.warn("squash_replace is depricated. Use node.flatten() instead", DeprecationWarning, stacklevel=2)
     offset = 0
     output = []
     for node in tree:
@@ -45,6 +52,11 @@ def squash_replace(data: bytes, tree: list[Node]) -> bytes:
 
 
 def obfuscation_counts(tree: list[Node]) -> Counter[str]:
+    warnings.warn(
+        "obfuscation_counts is obsolete. Use Counter(child.obfuscation for child in node) instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     counts: Counter[str] = Counter()
     for node in tree:
         if node.obfuscation:

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -1,0 +1,33 @@
+import pytest
+from multidecoder.node import Node
+
+DATA1 = b"12345HERE WE ARE54321"
+EXAMPLE1 = Node(
+    "",
+    DATA1,
+    "",
+    0,
+    len(DATA1),
+    children=[Node("test", b"And now for something completely different.", "different", 5, 16)],
+)
+
+
+def test_original_no_parent():
+    data = b"unmodified data"
+    assert Node("test", data, "", 0, len(data)).original == data
+
+
+def test_original_parent():
+    assert EXAMPLE1.children[0].original == b"HERE WE ARE"
+
+
+@pytest.mark.parametrize(
+    ("node", "flat"),
+    [
+        (EXAMPLE1, b"12345And now for something completely different.54321"),
+        (Node("", b"abc", "", 0, 3, children=[Node("", b"FIRST", "", 0, 2), Node("", b"SECOND", "", 1, 3)]), b"FIRSTc"),
+        (Node("", b"abc", "", 0, 3, children=[Node("", b"FIRST", "", 0, 3), Node("", b"SECOND", "", 0, 3)]), b"FIRST"),
+    ],
+)
+def test_flatten(node, flat):
+    assert node.flatten() == flat


### PR DESCRIPTION
* Depricate invert_tree, squash_replace, and obfuscation_counts

These methods are still based on the tree as a list of children model and are made irrelevant by new node methods. Since node is now iterable, invert_tree can be replaced by list(node). obfuscation_counts can be replaced with:
Counter(child.obfuscation for node in node).
Neither require a dedicated function anymore.
Since trees now have a root node squash_replace can now be a method of Node with no other arguments, this is implimented as Node.flatten().

* Add tests for Node.flatten() and fix comparison.

* Add Node.flatten() test for full overlap