### PR TITLE
Improve Hex blob extraction in MultiDecoder

### DIFF
--- a/src/multidecoder/decoders/base64.py
+++ b/src/multidecoder/decoders/base64.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 import binascii
 
 import regex as re
-
 from multidecoder.node import Node
 from multidecoder.registry import decoder
 
@@ -116,6 +115,8 @@ def find_Base64Decode(data: bytes) -> list[Node]:
 def find_FromBase64String(data: bytes) -> list[Node]:
     """
     Find the powershell function FromBase64String and decode its argument
+
+    Supported by https://github.com/CYB3RMX/Qu1cksc0pe/blob/1a349826b248e578b0a2ec8b152eeeddf059c388/Modules/powershell_analyzer.py#L53
     """
     out: list[Node] = []
     xorkey = re.search(rb"(?i)-b?xor\s*(\d{1,3})", data)

--- a/src/multidecoder/decoders/hex.py
+++ b/src/multidecoder/decoders/hex.py
@@ -1,18 +1,59 @@
 from __future__ import annotations
 
+from binascii import Error as binascii_error
 from binascii import unhexlify
 
 import regex as re
-
 from multidecoder.node import Node
 from multidecoder.registry import decoder
 
 HEX_RE = rb"((?:[a-f0-9]{2}){10,}|(?:[A-F0-9]{2}){10,})"
+FROMHEXSTRING_RE = rb"(?i)(\[System.Convert\]::)?FromHexString\('" + HEX_RE + rb"'\)"
 
 
 @decoder
 def find_hex(data: bytes) -> list[Node]:
+    """
+    Find all hexadecimal encoded sections in some data.
+
+    Args:
+        data: The data to search.
+    Returns:
+        A list of decoded hexadecimal sections and the location indexes of the section
+        in the original data.
+    """
     return [
         Node("", unhexlify(match.group(0)), "decoded.hexadecimal", *match.span(0))
         for match in re.finditer(HEX_RE, data)
     ]
+
+
+@decoder
+def find_FromHexString(data: bytes) -> list[Node]:
+    """
+    Find the powershell function FromHexString and decode its argument
+
+    Inspired by https://github.com/CYB3RMX/Qu1cksc0pe/blob/1a349826b248e578b0a2ec8b152eeeddf059c388/Modules/powershell_analyzer.py#L57
+    """
+    out: list[Node] = []
+    xorkey = re.search(rb"(?i)-b?xor\s*(\d{1,3})", data)
+    for match in re.finditer(FROMHEXSTRING_RE, data):
+        try:
+            hex = unhexlify(match.group(2))
+            hex_node = Node("powershell.bytes", hex, "encoding.hexidecimal", *match.span())
+            if xorkey:
+                key = int(xorkey.group(1))
+                hex = bytes(b ^ key for b in hex)
+                hex_node.children.append(
+                    Node(
+                        "powershell.bytes",
+                        hex,
+                        "cipher.xor" + str(key),
+                        end=len(hex),
+                        parent=hex_node,
+                    )
+                )
+            out.append(hex_node)
+        except binascii_error:
+            continue
+    return out

--- a/tests/test_decoders/test_hex.py
+++ b/tests/test_decoders/test_hex.py
@@ -1,5 +1,6 @@
 import regex as re
-from multidecoder.decoders.hex import HEX_RE, find_hex
+from multidecoder.decoders.hex import HEX_RE, find_FromHexString, find_hex
+from multidecoder.node import Node
 
 
 def test_empty():
@@ -16,3 +17,43 @@ def test_hex():
 
 def test_find_hex():
     assert find_hex(b"some encoded text".hex().encode())[0].value == b"some encoded text"
+
+
+# -- FromHexString --
+
+
+def test_fromhexstring_no_xor():
+    test = b"FromHexString('6475636b20676f657320717561636b')"
+    test2 = b"[System.Convert]::FromHexString('6475636b20676f657320717561636b')"
+    assert find_FromHexString(test) == [
+        Node(
+            type_="powershell.bytes",
+            value=b"duck goes quack",
+            obfuscation="encoding.hexidecimal",
+            start=0,
+            end=len(test),
+        )
+    ]
+    assert find_FromHexString(test2) == [
+        Node(
+            type_="powershell.bytes",
+            value=b"duck goes quack",
+            obfuscation="encoding.hexidecimal",
+            start=0,
+            end=len(test2),
+        )
+    ]
+
+
+def test_fromhexstring_xor():
+    test = b"FromHexString('4756404803444c4650035256424048')\n-bxor 35"
+    assert find_FromHexString(test) == [
+        Node(
+            type_="powershell.bytes",
+            value=b"GV@H\x03DLFP\x03RVB@H",
+            obfuscation="encoding.hexidecimal",
+            start=0,
+            end=test.find(b"\n"),
+            children=[Node("powershell.bytes", b"duck goes quack", "cipher.xor35", 0, 15)],
+        )
+    ]


### PR DESCRIPTION
QuickScope performs Base64 and Hex string extraction. Currently MultiDecoder looks at PowerShell's FromBase64String to pull out blobs. We should support PowerShell's FromHexString too.

https://github.com/CYB3RMX/Qu1cksc0pe/blob/master/Modules/powershell_analyzer.py