### PR TITLE
Adding neutered IOC detection and normalization method, inspired by Stoq

### DIFF
--- a/src/multidecoder/decoders/network.py
+++ b/src/multidecoder/decoders/network.py
@@ -29,10 +29,19 @@ IP_OBF = "ip_obfuscation"
 # Regexes
 _OCTET_RE = rb"(?:0x0*[a-f0-9]{1,2}|0*\d{1,3})"
 
-DOMAIN_RE = rb"(?i)\b(?:[a-z0-9-]+\.)+(?:xn--[a-z0-9]{4,18}|[a-z]{2,12})(?![a-z.-])"
-EMAIL_RE = rb"(?i)\b[a-z0-9._%+-]{3,}@(" + DOMAIN_RE[4:] + rb")\b"
+# Inspired by https://github.com/PUNCH-Cyber/stoq-plugins-public/blob/8c2c94e43ce54221121e8e3f542b54d255862078/iocextract/iocextract/iocextract.py#L64
+_DOT_RE = rb"(?:\.|\[\.\]|\<\.\>|\{\.\}|\(\.\)|\<DOT\>|\[DOT\]|\{DOT\}|\(DOT\))"
 
-IP_RE = rb"(?i)(?<![\w.])(?:" + _OCTET_RE + rb"[.]){3}" + _OCTET_RE + rb"(?![\w.])"
+# Inspired by https://github.com/PUNCH-Cyber/stoq-plugins-public/blob/8c2c94e43ce54221121e8e3f542b54d255862078/iocextract/iocextract/iocextract.py#L69
+_AT_RE = rb"(?:@|\[@\]|\<@\>|\{@\}|\(@\)|\<AT\>|\[AT\]|\{AT\}|\(AT\))"
+
+DOMAIN_RE = rb"(?i)\b(?:[a-z0-9-]+" + _DOT_RE + rb")+(?:xn--[a-z0-9]{4,18}|[a-z]{2,12})(?![a-z.-])"
+EMAIL_RE = rb"(?i)\b[a-z0-9._%+-]{3,}" + _AT_RE + rb"(" + DOMAIN_RE[4:] + rb")\b"
+
+IP_RE = rb"(?i)(?<![\w.])(?:" + _OCTET_RE + _DOT_RE + rb"){3}" + _OCTET_RE + rb"(?![\w.])"
+
+# Inspired by https://github.com/PUNCH-Cyber/stoq-plugins-public/blob/8c2c94e43ce54221121e8e3f542b54d255862078/iocextract/iocextract/iocextract.py#L71
+_HTTP_RE = rb"h(?:tt|xx)ps?|meows?"
 
 # Using some weird ranges to shorten the regex:
 # $-. is $%&'()*+,-. all of which are sub-delims $&'()*+, or unreserved .-
@@ -40,7 +49,7 @@ IP_RE = rb"(?i)(?<![\w.])(?:" + _OCTET_RE + rb"[.]){3}" + _OCTET_RE + rb"(?![\w.
 # #-/ is the same with # and /
 # #-& is #-/ but stopped before '
 URL_RE = (
-    rb"(?i)(?:ftp|https?)://"  # scheme
+    rb"(?i)(?:ftp|" + _HTTP_RE + rb")://"  # scheme
     rb"(?:[\w!$-.:;=~@]{,2000}@)?"  # userinfo
     rb"(?:(?!%5B)[%A-Z0-9.-]{4,253}|(?:\[|%5B)[%0-9A-F:]{3,117}(?:\]|%5D))"  # host
     rb"(?::[0-9]{0,5})?"  # port
@@ -48,6 +57,24 @@ URL_RE = (
     # The final char class stops urls from ending in ' ) , or .
     # to prevent trailing characters from being included in the url.
 )
+
+
+# Inspired by https://github.com/PUNCH-Cyber/stoq-plugins-public/blob/8c2c94e43ce54221121e8e3f542b54d255862078/iocextract/iocextract/iocextract.py#L157
+def normalize_ioc(ioc: bytes) -> bytes:
+    """Normalizes a neutered IOC"""
+    # First check dots
+    ioc = re.sub(_DOT_RE, b".", ioc, flags=re.IGNORECASE)
+
+    # Then check @s
+    ioc = re.sub(_AT_RE, b"@", ioc, flags=re.IGNORECASE)
+
+    # Finally check schemes
+    if ioc.startswith(b"hxxps") or ioc.startswith(b"meows"):
+        ioc = re.sub(_HTTP_RE, b"https", ioc, flags=re.IGNORECASE)
+    elif ioc.startswith(b"hxxp") or ioc.startswith(b"meow"):
+        ioc = re.sub(_HTTP_RE, b"http", ioc, flags=re.IGNORECASE)
+
+    return ioc
 
 
 # Regex validators
@@ -61,6 +88,7 @@ def is_domain(domain: bytes) -> bool:
     Returns:
         Whether domain has a valid top level domain.
     """
+    domain = normalize_ioc(domain)
     parts = domain.rsplit(b".", 1)
     if len(parts) != 2:
         return False
@@ -76,6 +104,7 @@ def is_ip(ip: bytes) -> bool:
     Returns:
         Whether ip is an IPv4 address.
     """
+    ip = normalize_ioc(ip)
     try:
         IPv4Address(ip.decode("ascii"))
     except (AddressValueError, UnicodeDecodeError):
@@ -93,6 +122,7 @@ def is_url(url: bytes) -> bool:
     Returns:
        Whether url is a URL.
     """
+    url = normalize_ioc(url)
     try:
         split = urlsplit(url)
     except ValueError:
@@ -142,6 +172,7 @@ def parse_ip(ip: bytes) -> Node:
     Returns:
         A node with the normalized IPv4 address as it's value.
     """
+    ip = normalize_ioc(ip)
     try:
         address = IPv4Address(socket.inet_aton(ip.decode()))
     except (OSError, AddressValueError, UnicodeDecodeError) as ex:
@@ -164,6 +195,7 @@ def parse_ipv6(ip: bytes) -> Node:
     Returns:
         A node with the normalized IPv6 address as it's value.
     """
+    ip = normalize_ioc(ip)
     try:
         address = IPv6Address(socket.inet_pton(socket.AF_INET6, ip.decode()))
     except (OSError, AddressValueError, UnicodeDecodeError) as ex:

--- a/tests/test_decoders/test_network.py
+++ b/tests/test_decoders/test_network.py
@@ -9,6 +9,7 @@ from multidecoder.decoders.network import (
     # find_domains,
     is_domain,
     is_url,
+    normalize_ioc,
     parse_ip,
 )
 from multidecoder.node import Node
@@ -37,6 +38,15 @@ from multidecoder.node import Node
         b"0x7f.0x0.0x0.0x1",
         # mixed ip address
         b"0xac.000000000000000000331.0246.174",
+        # Neutered IPs
+        b"127[.]0[.]0[.]1",
+        b"127<.>0<.>0<.>1",
+        b"127{.}0{.}0{.}1",
+        b"127(.)0(.)0(.)1",
+        b"127<DOT>0<DOT>0<DOT>1",
+        b"127[DOT]0[dot]0[DOT]1",
+        b"127{dOt}0{DOT}0{DOT}1",
+        b"127(DOT)0(DOT)0(DoT)1",
     ],
 )
 def test_IP_RE_match(ip):
@@ -75,6 +85,8 @@ def test_IP_RE_context(data, ip):
 
 def test_parse_ip():
     assert parse_ip(b"8.8.8.8") == Node("network.ip", b"8.8.8.8", "", 0, 7)
+    # Test neutered
+    assert parse_ip(b"8[.]8[.]8[.]8") == Node("network.ip", b"8.8.8.8", "", 0, 7)
 
 
 # Domain ----------------------------------------
@@ -86,6 +98,15 @@ def test_parse_ip():
         b"www.google.com",  # normal domain
         b"xn--bcher-kva.example",  # international domain
         b"some.website.xn--4gbrim",  # intenational top level domain
+        # Neutered domains
+        b"www[.]google[.]com",
+        b"www<.>google<.>com",
+        b"www{.}google{.}com",
+        b"www(.)google(.)com",
+        b"www<DOT>google<dot>com",
+        b"www[DOT]google[DOT]com",
+        b"www{dOt}google{DOT}com",
+        b"www(DOT)google(DOT)com",
     ],
 )
 def test_DOMAIN_RE_match(domain):
@@ -96,6 +117,8 @@ def test_DOMAIN_RE_match(domain):
 def test_is_valid_domain_re():
     assert is_domain(b"website.com")
     assert not is_domain(b"website.notatld")
+    # Test neutered
+    assert is_domain(b"website[DOT]com")
 
 
 # TODO: find a better way to avoid domain false positives than ignoring valid tlds
@@ -140,8 +163,23 @@ def test_DOMAIN_RE_context(data, domain):
 # Email -----------------------------------------
 
 
-def test_email_re():
-    assert re.match(EMAIL_RE, b"a_name@gmail.com")
+@pytest.mark.parametrize(
+    "email",
+    [
+        b"a_name@gmail.com",  # normal email
+        # Neutered emails
+        b"a_name[@]gmail[.]com",
+        b"a_name<@>gmail<.>com",
+        b"a_name{@}gmail{.}com",
+        b"a_name(@)gmail(.)com",
+        b"a_name<AT>gmail<DOT>com",
+        b"a_name[at]gmail[dOt]com",
+        b"a_name{At}gmail{DOT}com",
+        b"a_name(aT)gmail(DoT)com",
+    ],
+)
+def test_email_re(email):
+    assert re.match(EMAIL_RE, email)
 
 
 # URL -------------------------------------------
@@ -213,11 +251,21 @@ def test_email_re():
         b"http://%5B%3A%3A1]",  # This works in Chrome and Edge, the colons have to be percent encoded.
         b"http://[::1%5D",  # You wouldn't think this would work, but it still does on Chrome and Edge.
         b"http://[::1%5D/path",  # Even handles the rest of the url just fine.
+        # Neutered schemes are handled!
+        b"hxxps://google.com",
+        b"meow://google.com",
     ],
 )
 def test_URL_RE_matches(url):
     """Test that URL_RE matches expected URLs"""
     assert re.match(URL_RE, url).span() == (0, len(url))
+
+
+def test_URL_RE_false_positive():
+    """Test that URL_RE does not match potential false positives"""
+    # Neutered URLs with neutered domains are not handled by just this regular 
+    # expression, so the full domain is not captured
+    assert re.match(URL_RE, b"hxxps://google[.]com").span() == (0, 14)
 
 
 @pytest.mark.parametrize(
@@ -241,3 +289,33 @@ def test_URL_RE_context(data, url):
 
 def test_is_url():
     assert is_url(b"https://some.domain.com")
+    # Test neutered
+    assert is_url(b"meows://some[.]domain[.]com")
+
+
+# Normalize -------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "value, expected_value",
+    [
+        # Normal email
+        (b"a_name@gmail.com", b"a_name@gmail.com"),
+        # Normal domain
+        (b"www.google.com", b"www.google.com"),
+        # Normal IP
+        (b"127.0.0.1", b"127.0.0.1"),
+        # Normal URL
+        (b"https://some.domain.com", b"https://some.domain.com"),
+        # Neutered email
+        (b"a_name[@]gmail[.]com", b"a_name@gmail.com"),
+        # Neutered domain
+        (b"www[.]google[.]com", b"www.google.com"),
+        # Neutered IP
+        (b"127[.]0{.}0(.)1", b"127.0.0.1"),
+        # Neutered URL
+        (b"hxxps://some[.]domain[.]com", b"https://some.domain.com"),
+    ],
+)
+def test_normalize_ioc(value, expected_value):
+    assert normalize_ioc(value) == expected_value


### PR DESCRIPTION
If a neutered IOC is seen in a file, we miss it.

Stoq has a module that uses regexes that can handle "neutered" IOCs for dots, @symbols, https protocols, etc.

https://github.com/PUNCH-Cyber/stoq-plugins-public/blob/master/iocextract/iocextract/iocextract.py#L64

They then convert these neutered IOCs to un-neutered