### PR TITLE
Prevent false positives in windows paths

### DIFF
--- a/src/multidecoder/decoders/network.py
+++ b/src/multidecoder/decoders/network.py
@@ -29,7 +29,7 @@ IP_OBF = "ip_obfuscation"
 # Regexes
 _OCTET_RE = rb"(?:0x0*[a-f0-9]{1,2}|0*\d{1,3})"
 
-DOMAIN_RE = rb"(?i)\b(?:[a-z0-9-]+\.)+(?:xn--[a-z0-9]{4,18}|[a-z]{2,12})(?![a-z.-])"
+DOMAIN_RE = rb"(?i)(?<![-\w.\\])(?:[a-z0-9-]+\.)+(?:xn--[a-z0-9]{4,18}|[a-z]{2,12})(?![a-z.-])"
 EMAIL_RE = rb"(?i)\b[a-z0-9._%+-]{3,}@(" + DOMAIN_RE[4:] + rb")\b"
 
 IP_RE = rb"(?i)(?<![\w.])(?:" + _OCTET_RE + rb"[.]){3}" + _OCTET_RE + rb"(?![\w.])"

--- a/tests/test_decoders/test_network.py
+++ b/tests/test_decoders/test_network.py
@@ -93,6 +93,17 @@ def test_DOMAIN_RE_match(domain):
     assert re.match(DOMAIN_RE, domain).end() == len(domain)
 
 
+@pytest.mark.parametrize(
+    "domain",
+    [
+        b"C:\\path\\looks-like-a-domain.com",
+        b"C:\\path\\looks.like.a.domain.com",
+    ],
+)
+def test_DOMAIN_RE_false_positives(domain):
+    assert not re.search(DOMAIN_RE, domain)
+
+
 def test_is_valid_domain_re():
     assert is_domain(b"website.com")
     assert not is_domain(b"website.notatld")


### PR DESCRIPTION
If the filename at the end of a windows path happens to have a file extension that is also a tld, it can look like a domain name. Preventing matching after \ . and - in addition to \w (\b) prevents it.