### PR TITLE
Hack to prevent urls from matching past the end of an external context

### DIFF
--- a/src/multidecoder/decoders/network.py
+++ b/src/multidecoder/decoders/network.py
@@ -127,14 +127,13 @@ def find_urls(data: bytes) -> list[Node]:
     # need to do actual context aware search
     contexts = {
         ord("'"): ord("'"),
-        ord("{"): ord("}"),
         ord("("): ord(")"),
     }
     out = []
     for match in re.finditer(URL_RE, data):
         group = match.group()
         prev = data[match.start() - 1]
-        if prev in contexts:
+        if match.start() != 0 and prev in contexts:
             group = group[: group.find(contexts[prev])]
         if not is_url(group):
             continue

--- a/tests/test_decoders/test_network.py
+++ b/tests/test_decoders/test_network.py
@@ -6,6 +6,7 @@ from multidecoder.decoders.network import (
     EMAIL_RE,
     IP_RE,
     URL_RE,
+    find_urls,
     # find_domains,
     is_domain,
     is_url,
@@ -252,3 +253,20 @@ def test_URL_RE_context(data, url):
 
 def test_is_url():
     assert is_url(b"https://some.domain.com")
+
+
+def test_find_url():
+    assert find_urls(b"'https://example.com/path'after_the_url") == [
+        Node(
+            "network.url",
+            b"https://example.com/path",
+            "",
+            1,
+            39,
+            children=[
+                Node("network.url.scheme", b"https", "", 0, 5),
+                Node("network.domain", b"example.com", "", 8, 19),
+                Node("network.url.path", b"/path", "", 19, 24),
+            ],
+        )
+    ]

--- a/tests/test_decoders/test_network.py
+++ b/tests/test_decoders/test_network.py
@@ -255,18 +255,44 @@ def test_is_url():
     assert is_url(b"https://some.domain.com")
 
 
-def test_find_url():
-    assert find_urls(b"'https://example.com/path'after_the_url") == [
-        Node(
-            "network.url",
-            b"https://example.com/path",
-            "",
-            1,
-            39,
-            children=[
-                Node("network.url.scheme", b"https", "", 0, 5),
-                Node("network.domain", b"example.com", "", 8, 19),
-                Node("network.url.path", b"/path", "", 19, 24),
+@pytest.mark.parametrize(
+    ("data", "urls"),
+    [
+        (
+            b"'https://example.com/path'after_the_url",
+            [
+                Node(
+                    "network.url",
+                    b"https://example.com/path",
+                    "",
+                    1,
+                    39,
+                    children=[
+                        Node("network.url.scheme", b"https", "", 0, 5),
+                        Node("network.domain", b"example.com", "", 8, 19),
+                        Node("network.url.path", b"/path", "", 19, 24),
+                    ],
+                )
             ],
-        )
-    ]
+        ),
+        (
+            b"https://example.com/path'still_the_url'",
+            [
+                Node(
+                    "network.url",
+                    b"https://example.com/path'still_the_url",
+                    "",
+                    0,
+                    38,
+                    children=[
+                        Node("network.url.scheme", b"https", "", 0, 5),
+                        Node("network.domain", b"example.com", "", 8, 19),
+                        Node("network.url.path", b"/path'still_the_url", "", 19, 38),
+                    ],
+                )
+            ],
+        ),
+    ],
+)
+def test_find_url(data, urls):
+    assert find_urls(data) == urls

--- a/tests/test_decoders/test_network.py
+++ b/tests/test_decoders/test_network.py
@@ -259,6 +259,23 @@ def test_is_url():
     ("data", "urls"),
     [
         (
+            b" https://example.com/path'),.;still_url ",
+            [
+                Node(
+                    "network.url",
+                    b"https://example.com/path'),.;still_url",
+                    "",
+                    1,
+                    39,
+                    children=[
+                        Node("network.url.scheme", b"https", "", 0, 5),
+                        Node("network.domain", b"example.com", "", 8, 19),
+                        Node("network.url.path", b"/path'),.;still_url", "", 19, 38),
+                    ],
+                )
+            ],
+        ),
+        (
             b"'https://example.com/path'after_the_url",
             [
                 Node(


### PR DESCRIPTION
This will eventually have to be reworked for strings that start farther before the url, but for now this should prevent the common false positives.