### PR TITLE
Prevent url from ending with ;

### DIFF
--- a/src/multidecoder/decoders/network.py
+++ b/src/multidecoder/decoders/network.py
@@ -44,8 +44,8 @@ URL_RE = (
     rb"(?:[\w!$-.:;=~@]{,2000}@)?"  # userinfo
     rb"(?:(?!%5B)[%A-Z0-9.-]{4,253}|(?:\[|%5B)[%0-9A-F:]{3,117}(?:\]|%5D))"  # host
     rb"(?::[0-6]?[0-9]{0,4})?"  # port
-    rb"(?:[/?#](?:[\w!#-/:;=@?~]{,2000}[\w!#-&(*+\-/:;=@?~])?)?"  # path, query and fragment
-    # The final char class stops urls from ending in ' ) , or .
+    rb"(?:[/?#](?:[\w!#-/:;=@?~]{,2000}[\w!#-&(*+\-/:=@?~])?)?"  # path, query and fragment
+    # The final char class stops urls from ending in ' ) , . or ;
     # to prevent trailing characters from being included in the url.
 )
 

--- a/tests/test_decoders/test_network.py
+++ b/tests/test_decoders/test_network.py
@@ -243,6 +243,7 @@ def test_URL_RE_matches(url):
         ),
         (b"barefunction(https://example.com) works", b"https://example.com"),
         (b'in a string content "https://example.com"works.', b"https://example.com"),
+        (b"'https://example.com/'; ", b"https://example.com/"),
     ],
 )
 def test_URL_RE_context(data, url):


### PR DESCRIPTION
Helps with trailing characters in javascript and other scripting languages with c-like syntax.