### PR TITLE
Fix WINDOWS_PATH_RE regex and tests

### DIFF
--- a/src/multidecoder/decoders/path.py
+++ b/src/multidecoder/decoders/path.py
@@ -16,10 +16,10 @@ PATH_RE = rb"[.]?[.]?/(\w{3,}/)+[\w.]{3,}"
 # Windows Paths
 # See https://learn.microsoft.com/en-us/dotnet/standard/io/file-path-formats
 WINDOWS_PATH_RE = (
-    rb"(?i)(?:\\\\[.?]\\(?:[a-z]:\\|UNC\\|Volume\{[a-z0-9-]{36}\}\\)?"  # DOS device path
-    rb"|\\\\[\w.-]+(?:@SSL)?(?:@\d{,5})?\\(?:[a-z]$\\)?"  # UNC path
+    rb"(?i)(?:\\\\[.?]\\(?:[a-z]:\\|UNC\\[\w.-]+\\(?:[a-z][$]\\)?|Volume\{[a-z0-9-]{36}\}\\)?"  # DOS device path
+    rb"|\\\\[\w.-]+(?:@SSL)?(?:@\d{,5})?\\(?:[a-z][$]\\)?"  # UNC path
     rb"|[a-z]:\\?|\\)?"  # absolute or drive relative path
-    rb"(?:(?:.|..|[\w.-]{3,})\\)+"  # path segments
+    rb"(?:(?:[.]|[.][.]|[\w.-]{3,})\\)+"  # path segments
     rb"[\w.-]{3,}"  # filename
 )
 

--- a/tests/test_decoders/test_path.py
+++ b/tests/test_decoders/test_path.py
@@ -65,7 +65,14 @@ def test_windows_path_re(path):
     assert re.search(WINDOWS_PATH_RE, path).group() == path
 
 
-@pytest.mark.parametrize("fpos", [b""])
+@pytest.mark.parametrize(
+    "fpos",
+    [
+        b"",
+        b"\\",
+        Rb"\"\\temp",
+    ],
+)
 def test_windows_path_re_fpos(fpos):
     assert not re.search(WINDOWS_PATH_RE, fpos)
 
@@ -116,30 +123,30 @@ def test_windows_path_re_fpos(fpos):
             ],
         ),
         (
-            Rb"\\?\UNC\127.0.0.1\path\to\file.exe",
+            Rb"\\?\UNC\127.0.0.1\path\file.exe",
             [
                 Node(
                     "windows.device.path",
-                    Rb"\\?\UNC\127.0.0.1\path\to\file.exe",
+                    Rb"\\?\UNC\127.0.0.1\path\file.exe",
                     "",
                     0,
-                    34,
+                    31,
                     children=[
                         Node("network.ip", b"127.0.0.1", "", 8, 17),
-                        Node("executable.filename", b"file.exe", "", 26, 34),
+                        Node("executable.filename", b"file.exe", "", 23, 31),
                     ],
                 ),
             ],
         ),
         (
-            Rb"c:\temp\\\\\\foo\..\\.\.\\test-file",
+            Rb"c:\temp\foo\..\.\.\test-file",
             [
                 Node(
                     "windows.path",
                     Rb"c:\temp\test-file",
                     "windows.dotpath",
                     0,
-                    35,
+                    28,
                 )
             ],
         ),


### PR DESCRIPTION
- fixed literal dot
- fixed device UNC path drive letter
- removed tests for multiple backslashed in a row to match regex restrictions