### PR TITLE
Allow find_domains to find unc path domains with port

### DIFF
--- a/src/multidecoder/decoders/network.py
+++ b/src/multidecoder/decoders/network.py
@@ -30,7 +30,7 @@ IP_OBF = "ip_obfuscation"
 _OCTET_RE = rb"(?:0x0*[a-f0-9]{1,2}|0*\d{1,3})"
 
 # Specifically allowing 0 after domain names for PE strings
-DOMAIN_RE = rb"(?i)(?<![-$\w.\\])(?:[a-z0-9-]+\.)+(?:xn--[a-z0-9]{4,18}|[a-z]{2,12})(?![a-z1-9.(=_@-])"
+DOMAIN_RE = rb"(?i)(?<![-$\w.\\])(?:[a-z0-9-]+\.)+(?:xn--[a-z0-9]{4,18}|[a-z]{2,12})(?![a-z1-9.(=_-])"
 EMAIL_RE = rb"(?i)\b[a-z0-9._%+-]{3,}@(" + DOMAIN_RE[4:] + rb")\b"
 
 IP_RE = rb"(?i)(?<![\w.-])(?:" + _OCTET_RE + rb"[.]){3}" + _OCTET_RE + rb"(?![\w.=-])"
@@ -1276,6 +1276,9 @@ def find_domains(data: bytes) -> list[Node]:
 
         if preceeding_character == "/" and (start < 2 or data[start - 2] != ord("/")):
             continue  # filename not domain
+
+        if next_character == "@" and end + 1 < len(data) and chr(data[end + 1]).isalpha():
+            continue  # email username, not domain
 
         if (
             preceeding_character

--- a/tests/test_decoders/test_network.py
+++ b/tests/test_decoders/test_network.py
@@ -120,7 +120,6 @@ def test_DOMAIN_RE_match(domain):
         b'fi.search="',
         b"variable.call(",
         b"Microsoft.Win32",
-        b"delete.me@",
     ],
 )
 def test_DOMAIN_RE_false_positives(domain):
@@ -264,6 +263,7 @@ def test_domain_is_false_positive_real_domain(domain):
         (b"./example.com ", []),
         (b"https://example.com/c9k5y4.zip", [Node("network.domain", b"example.com", "", 8, 19)]),
         (b"/c9k5y4.zip", []),
+        (b"example-domain.net@80\\something.something", [Node("network.domain", b"example-domain.net", "", 0, 18)]),
     ],
 )
 def test_find_domains(data, domains):


### PR DESCRIPTION
Narrow email username domain filter to check for a letter after the @. Allows the unc path syntax where a domain can be followed by @ and a port number.